### PR TITLE
Updates workflow to use shared workflow definitions (#7)

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -18,10 +18,6 @@ versions:
         refs:
           - source: github.com/cloud-native-toolkit/terraform-gitops-namespace.git
             version: ">= 1.0.0"
-      - id: cp4d-operator
-        refs:
-          - source: github.com/cloud-native-toolkit/terraform-gitops-cp4d-operator.git
-            version: ">= 1.0.0"
     variables:
       - name: gitops_config
         moduleRef:


### PR DESCRIPTION
Removed CP4 Dependency since this is first component for DB2 and not sure CP4 Operator is added

      - id: cp4d-operator
        refs:
          - source: github.com/cloud-native-toolkit/terraform-gitops-cp4d-operator.git
            version: ">= 1.0.0"